### PR TITLE
Replace http in url with https

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <script>
-      var url = 'http://mdipierro.github.io/stupid.css/index.html';
+      var url = 'https://mdipierro.github.io/stupid.css/index.html';
       if(window.location.href!=url) window.location=url;
     </script>
   </head>


### PR DESCRIPTION
With https everywhere, the browser automatically redirects you to 'https://mdipierro.github.io/stupid.css/index.html' when given window.location='http://mdipierro.github.io/stupid.css/index.html'. This causes an infinite redirection loop.
